### PR TITLE
fix indexing when trimming trading days

### DIFF
--- a/strategies/seek/seek.go
+++ b/strategies/seek/seek.go
@@ -212,7 +212,7 @@ func (seek *SeekingAlphaQuant) Compute(ctx context.Context, manager *data.Manage
 			return nil, nil, err
 		}
 		if !isTradeDay {
-			tradeDays = tradeDays[:endIdx-1]
+			tradeDays = tradeDays[:endIdx]
 		}
 	}
 


### PR DESCRIPTION
Seeking Alpha was trimming 2 dates from trading days when it was not a valid trading day which caused the issue
described in #121 

closes #121