### PR TITLE
fix(alert): gate daily alerts on the trading-day calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GET /portfolios/{slug}/trailing-returns` for benchmark windowed returns.
 
 ### Fixed
+- Daily alert emails no longer fire on weekends and NYSE holidays. They are
+  now gated on the trading-day calendar, matching the weekly and monthly
+  alerts, so a non-trading-day run no longer sends an update (with a
+  spurious one-day return computed off stale data).
 - Snapshot reads no longer loop in `recalculating` forever. Each backtest
   run now writes its own snapshot file under
   `<snapshots_dir>/<portfolio_id>/<run_id>.sqlite`, so pruning older runs

--- a/alert/evaluate.go
+++ b/alert/evaluate.go
@@ -44,6 +44,9 @@ func isDue(a Alert, now time.Time) bool {
 	case FrequencyScheduledRun:
 		return true
 	case FrequencyDaily:
+		if !tradingdays.IsTrading(nowET) {
+			return false
+		}
 		if a.LastSentAt == nil {
 			return true
 		}

--- a/alert/evaluate_test.go
+++ b/alert/evaluate_test.go
@@ -27,6 +27,9 @@ func ptrTime(t time.Time) *time.Time { return &t }
 func TestIsDue(t *testing.T) {
 	tuesday := time.Date(2025, 4, 22, 15, 0, 0, 0, time.UTC)
 	friday := time.Date(2025, 4, 25, 15, 0, 0, 0, time.UTC)
+	saturday := time.Date(2025, 4, 26, 15, 0, 0, 0, time.UTC)
+	sunday := time.Date(2025, 4, 27, 15, 0, 0, 0, time.UTC)
+	memorialDay := time.Date(2025, 5, 26, 15, 0, 0, 0, time.UTC) // NYSE holiday
 	lastOfApril := time.Date(2025, 4, 30, 15, 0, 0, 0, time.UTC)
 
 	yesterday := ptrTime(tuesday.AddDate(0, 0, -1))
@@ -43,6 +46,9 @@ func TestIsDue(t *testing.T) {
 		{"daily/no prior", Alert{ID: uuid.New(), Frequency: FrequencyDaily}, tuesday, true},
 		{"daily/sent yesterday", Alert{ID: uuid.New(), Frequency: FrequencyDaily, LastSentAt: yesterday}, tuesday, true},
 		{"daily/sent today", Alert{ID: uuid.New(), Frequency: FrequencyDaily, LastSentAt: sameDay}, tuesday, false},
+		{"daily/saturday no prior", Alert{ID: uuid.New(), Frequency: FrequencyDaily}, saturday, false},
+		{"daily/sunday no prior", Alert{ID: uuid.New(), Frequency: FrequencyDaily}, sunday, false},
+		{"daily/holiday no prior", Alert{ID: uuid.New(), Frequency: FrequencyDaily}, memorialDay, false},
 		{"weekly/not last day", Alert{ID: uuid.New(), Frequency: FrequencyWeekly}, tuesday, false},
 		{"weekly/last day no prior", Alert{ID: uuid.New(), Frequency: FrequencyWeekly}, friday, true},
 		{"weekly/last day sent today", Alert{ID: uuid.New(), Frequency: FrequencyWeekly, LastSentAt: ptrTime(friday)}, friday, false},


### PR DESCRIPTION
## Problem

A portfolio update email went out on Sunday, May 24, 2026. Daily alerts should only fire on trading days.

The open-ended daily backtest runs every day at 8 PM ET via `ClaimDue` — weekends and holidays included. After each run, `NotifyRunComplete` asks `isDue` whether to email. The weekly and monthly branches gate on the trading-day calendar, but the `FrequencyDaily` branch had no such guard, so a Saturday/Sunday/holiday run still sent an update. That also explains the bogus +0.4% one-day return: a non-trading-day run re-derives the day-return off stale prior-close data.

## Fix

`alert/evaluate.go` — daily alerts now skip non-trading days via `tradingdays.IsTrading(nowET)`, matching the existing weekly/monthly pattern.

Added test cases for daily-on-Saturday, daily-on-Sunday, and daily-on-holiday (Memorial Day 2025) — all expect no email.

## Note

This stops the emails on non-trading days. The underlying backtest still executes daily (it advances `last_run_at`); it just no longer notifies. Gating the run itself would be a separate change in `ClaimDue`.

## Verification
- `go test ./alert/...` passes (incl. new cases)
- `golangci-lint run ./alert/...` clean