### PR TITLE
fix(scheduler): fire at 8 PM ET and stop manual runs from eating scheduled alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   screen better (Apple Mail / iOS Mail; Gmail's app shows the wide table).
 - Alert email returns that round to zero now render as a neutral "0.0%"
   rather than a green "+0.0%", so a flat day isn't shown as a gain.
+- Scheduled portfolio runs and their alert emails now fire at 8:00 PM
+  US/Eastern regardless of the server's timezone. On a UTC host they were
+  firing at 8:00 PM UTC (4:00 PM Eastern, before the market close).
+- A manual "Run now" no longer sends an alert email, and no longer counts as
+  the day's scheduled run, so it can no longer suppress the evening scheduled
+  update or its alert email.
 
 ### Added
 - Periodic orphan-snapshot sweep removes any `<snapshots_dir>/<portfolio_id>/<run_id>.sqlite`

--- a/backtest/dispatcher.go
+++ b/backtest/dispatcher.go
@@ -25,11 +25,20 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Run trigger values, persisted on backtest_runs.triggered_by. Scheduled runs
+// are dispatched by the nightly scheduler; manual runs come from a user action.
+// The distinction drives two behaviors: ClaimDue counts only scheduled runs as
+// "ran today", and only scheduled runs send alert emails.
+const (
+	TriggerScheduled = "scheduled"
+	TriggerManual    = "manual"
+)
+
 // RunStore is the subset of portfolio.RunStore the dispatcher needs.
 // Declared here (not imported from portfolio) to avoid the cycle
 // backtest → portfolio.
 type RunStore interface {
-	CreateRun(ctx context.Context, portfolioID uuid.UUID, status string) (RunRow, error)
+	CreateRun(ctx context.Context, portfolioID uuid.UUID, status, trigger string) (RunRow, error)
 	UpdateRunRunning(ctx context.Context, runID uuid.UUID) error
 	UpdateRunSuccess(ctx context.Context, runID uuid.UUID, snapshotPath string, durationMs int32) error
 	UpdateRunFailed(ctx context.Context, runID uuid.UUID, errMsg string, durationMs int32) error
@@ -83,6 +92,7 @@ type SetKpis struct {
 type task struct {
 	portfolioID uuid.UUID
 	runID       uuid.UUID
+	scheduled   bool
 }
 
 // Dispatcher is a bounded worker-pool that funnels task submissions to
@@ -91,7 +101,7 @@ type Dispatcher struct {
 	cfg     Config
 	runner  Runner
 	runs    RunStore
-	runFn   func(ctx context.Context, portfolioID, runID uuid.UUID) error
+	runFn   func(ctx context.Context, portfolioID, runID uuid.UUID, scheduled bool) error
 	tasks   chan task
 	wg      sync.WaitGroup
 	ctx     context.Context
@@ -102,7 +112,7 @@ type Dispatcher struct {
 // NewDispatcher builds a dispatcher. runFn is the orchestration callback;
 // production passes backtest.Run (Task 15). Tests pass nil and rely on the
 // direct-runner fallback for concurrency assertions.
-func NewDispatcher(cfg Config, runner Runner, runs RunStore, runFn func(ctx context.Context, portfolioID, runID uuid.UUID) error) *Dispatcher {
+func NewDispatcher(cfg Config, runner Runner, runs RunStore, runFn func(ctx context.Context, portfolioID, runID uuid.UUID, scheduled bool) error) *Dispatcher {
 	cfg.ApplyDefaults()
 	return &Dispatcher{
 		cfg:    cfg,
@@ -131,13 +141,13 @@ func (d *Dispatcher) Start(parent context.Context) {
 	log.Info().Int("workers", d.cfg.MaxConcurrency).Msg("backtest dispatcher started")
 }
 
-func (d *Dispatcher) Submit(ctx context.Context, portfolioID uuid.UUID) (uuid.UUID, error) {
-	run, err := d.runs.CreateRun(ctx, portfolioID, "queued")
+func (d *Dispatcher) Submit(ctx context.Context, portfolioID uuid.UUID, trigger string) (uuid.UUID, error) {
+	run, err := d.runs.CreateRun(ctx, portfolioID, "queued", trigger)
 	if err != nil {
 		return uuid.Nil, err
 	}
 	select {
-	case d.tasks <- task{portfolioID: portfolioID, runID: run.ID}:
+	case d.tasks <- task{portfolioID: portfolioID, runID: run.ID, scheduled: trigger == TriggerScheduled}:
 		return run.ID, nil
 	default:
 		// Release the partial unique index on backtest_runs so a future
@@ -168,7 +178,7 @@ func (d *Dispatcher) worker() {
 	defer d.wg.Done()
 	for t := range d.tasks {
 		if d.runFn != nil {
-			if err := d.runFn(d.ctx, t.portfolioID, t.runID); err != nil {
+			if err := d.runFn(d.ctx, t.portfolioID, t.runID, t.scheduled); err != nil {
 				log.Error().Err(err).Stringer("run_id", t.runID).Msg("backtest run failed")
 			}
 			continue

--- a/backtest/dispatcher_test.go
+++ b/backtest/dispatcher_test.go
@@ -68,7 +68,7 @@ type fakeRunStore struct {
 
 func newFakeRunStore() *fakeRunStore { return &fakeRunStore{} }
 
-func (f *fakeRunStore) CreateRun(_ context.Context, pid uuid.UUID, status string) (backtest.RunRow, error) {
+func (f *fakeRunStore) CreateRun(_ context.Context, pid uuid.UUID, status, _ string) (backtest.RunRow, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	runID := uuid.New()
@@ -101,12 +101,12 @@ var _ = Describe("Dispatcher", func() {
 		// buffer (MaxConcurrency*4 = 8) has the headroom to absorb the rest
 		// without racing the workers' first reads.
 		for range 2 {
-			_, err := d.Submit(context.Background(), uuid.New())
+			_, err := d.Submit(context.Background(), uuid.New(), backtest.TriggerScheduled)
 			Expect(err).NotTo(HaveOccurred())
 		}
 		Eventually(func() int64 { return atomic.LoadInt64(&runner.active) }).Should(Equal(int64(2)))
 		for range 8 {
-			_, err := d.Submit(context.Background(), uuid.New())
+			_, err := d.Submit(context.Background(), uuid.New(), backtest.TriggerScheduled)
 			Expect(err).NotTo(HaveOccurred())
 		}
 		Consistently(func() int64 { return atomic.LoadInt64(&runner.peak) }).Should(Equal(int64(2)))
@@ -125,9 +125,9 @@ var _ = Describe("Dispatcher", func() {
 
 		// Fill the queue: 1 in-flight + 4 buffered == 5; 6th should fail.
 		for range 5 {
-			_, _ = d.Submit(context.Background(), uuid.New())
+			_, _ = d.Submit(context.Background(), uuid.New(), backtest.TriggerScheduled)
 		}
-		_, err := d.Submit(context.Background(), uuid.New())
+		_, err := d.Submit(context.Background(), uuid.New(), backtest.TriggerScheduled)
 		Expect(err).To(MatchError(backtest.ErrQueueFull))
 	})
 
@@ -148,15 +148,15 @@ var _ = Describe("Dispatcher", func() {
 		// Submit one and wait until the worker is actively blocked in Run().
 		// Otherwise on a slow scheduler the channel fills before the worker
 		// starts consuming, and more than one Submit hits the default branch.
-		_, err := d.Submit(context.Background(), uuid.New())
+		_, err := d.Submit(context.Background(), uuid.New(), backtest.TriggerScheduled)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(runner.started).Should(BeClosed())
 
 		// Channel buffer is MaxConcurrency*4 = 4. Fill it.
 		for range 4 {
-			_, _ = d.Submit(context.Background(), uuid.New())
+			_, _ = d.Submit(context.Background(), uuid.New(), backtest.TriggerScheduled)
 		}
-		_, err = d.Submit(context.Background(), uuid.New())
+		_, err = d.Submit(context.Background(), uuid.New(), backtest.TriggerScheduled)
 		Expect(err).To(MatchError(backtest.ErrQueueFull))
 
 		rs.mu.Lock()

--- a/backtest/run.go
+++ b/backtest/run.go
@@ -88,12 +88,12 @@ func (o *orchestrator) WithProgressHub(h *ProgressHub) *orchestrator {
 //  5. fsyncs and renames the tmp file to its final path.
 //  6. Opens the snapshot, reads KPIs, and writes them back to the DB.
 //  7. On any failure, marks both the portfolio and run as failed.
-func (o *orchestrator) Run(ctx context.Context, portfolioID, runID uuid.UUID) error {
+func (o *orchestrator) Run(ctx context.Context, portfolioID, runID uuid.UUID, scheduled bool) error {
 	started := time.Now()
 
 	row, err := o.ps.GetByID(ctx, portfolioID)
 	if err != nil {
-		return o.fail(ctx, portfolioID, runID, started, fmt.Errorf("load portfolio: %w", err))
+		return o.fail(ctx, portfolioID, runID, started, scheduled, fmt.Errorf("load portfolio: %w", err))
 	}
 	if row.Status == "running" {
 		_ = o.rs.UpdateRunFailed(ctx, runID, "portfolio already running",
@@ -102,12 +102,12 @@ func (o *orchestrator) Run(ctx context.Context, portfolioID, runID uuid.UUID) er
 	}
 
 	if err := o.ps.MarkRunningTx(ctx, portfolioID, runID); err != nil {
-		return o.fail(ctx, portfolioID, runID, started, fmt.Errorf("mark running: %w", err))
+		return o.fail(ctx, portfolioID, runID, started, scheduled, fmt.Errorf("mark running: %w", err))
 	}
 
 	artifact, cleanup, err := o.resolve(ctx, row.StrategyCloneURL, row.StrategyVer)
 	if err != nil {
-		return o.fail(ctx, portfolioID, runID, started, fmt.Errorf("%w: %w", ErrStrategyNotInstalled, err))
+		return o.fail(ctx, portfolioID, runID, started, scheduled, fmt.Errorf("%w: %w", ErrStrategyNotInstalled, err))
 	}
 	defer cleanup()
 
@@ -116,7 +116,7 @@ func (o *orchestrator) Run(ctx context.Context, portfolioID, runID uuid.UUID) er
 	// the active snapshot, and let users diff successive runs.
 	portfolioDir := filepath.Join(o.cfg.SnapshotsDir, portfolioID.String())
 	if err := os.MkdirAll(portfolioDir, 0o750); err != nil {
-		return o.fail(ctx, portfolioID, runID, started, fmt.Errorf("mkdir snapshots subdir: %w", err))
+		return o.fail(ctx, portfolioID, runID, started, scheduled, fmt.Errorf("mkdir snapshots subdir: %w", err))
 	}
 	tmp := filepath.Join(portfolioDir, runID.String()+".sqlite.tmp")
 	final := filepath.Join(portfolioDir, runID.String()+".sqlite")
@@ -136,28 +136,30 @@ func (o *orchestrator) Run(ctx context.Context, portfolioID, runID uuid.UUID) er
 		Timeout:        o.cfg.Timeout,
 		ProgressWriter: progressWriter,
 	}); err != nil {
-		return o.fail(ctx, portfolioID, runID, started, err)
+		return o.fail(ctx, portfolioID, runID, started, scheduled, err)
 	}
 
 	if err := fsyncAndRename(tmp, final); err != nil {
-		return o.fail(ctx, portfolioID, runID, started, err)
+		return o.fail(ctx, portfolioID, runID, started, scheduled, err)
 	}
 
 	kp, err := readKpisFromSnapshot(ctx, final)
 	if err != nil {
-		return o.fail(ctx, portfolioID, runID, started, err)
+		return o.fail(ctx, portfolioID, runID, started, scheduled, err)
 	}
 
 	if err := o.ps.MarkReadyTx(ctx, portfolioID, runID, final,
 		kp.CurrentValue, kp.YtdReturn, kp.MaxDrawdown, kp.Sharpe, kp.Cagr,
 		kp.InceptionDate, durationMs(time.Since(started))); err != nil {
-		return o.fail(ctx, portfolioID, runID, started, fmt.Errorf("mark ready: %w", err))
+		return o.fail(ctx, portfolioID, runID, started, scheduled, fmt.Errorf("mark ready: %w", err))
 	}
 	o.prune(ctx, portfolioID)
 	if o.hub != nil {
 		o.hub.Complete(runID, "success", "")
 	}
-	if o.notifier != nil {
+	// Manual runs do not emit alert emails -- the user is already watching the
+	// run. Only scheduled runs feed the cadence-based alert path.
+	if o.notifier != nil && scheduled {
 		if err := o.notifier.NotifyRunComplete(ctx, portfolioID, runID, true); err != nil {
 			log.Warn().Err(err).Stringer("portfolio_id", portfolioID).Msg("alert notification failed")
 		}
@@ -248,7 +250,7 @@ func (o *orchestrator) prune(ctx context.Context, portfolioID uuid.UUID) {
 // fail records the failure on both the portfolio and run rows, then returns
 // an appropriate wrapped error. Context cancellation is re-wrapped as
 // ErrTimedOut to give callers a consistent sentinel.
-func (o *orchestrator) fail(ctx context.Context, portfolioID, runID uuid.UUID, started time.Time, err error) error {
+func (o *orchestrator) fail(ctx context.Context, portfolioID, runID uuid.UUID, started time.Time, scheduled bool, err error) error {
 	msg := err.Error()
 	if len(msg) > 2048 {
 		msg = msg[:2048]
@@ -258,7 +260,9 @@ func (o *orchestrator) fail(ctx context.Context, portfolioID, runID uuid.UUID, s
 	if o.hub != nil {
 		o.hub.Complete(runID, "failed", msg)
 	}
-	if o.notifier != nil {
+	// Manual runs do not emit alert emails, including failure alerts; the user
+	// initiating the run sees the error directly. Only scheduled runs notify.
+	if o.notifier != nil && scheduled {
 		if notifyErr := o.notifier.NotifyRunComplete(ctx, portfolioID, runID, false); notifyErr != nil {
 			log.Warn().Err(notifyErr).Stringer("portfolio_id", portfolioID).Msg("alert notification failed")
 		}

--- a/backtest/run_test.go
+++ b/backtest/run_test.go
@@ -89,6 +89,19 @@ func (f *fakeRunStoreFull) UpdateRunFailed(_ context.Context, _ uuid.UUID, msg s
 	return nil
 }
 
+// fakeNotifier records whether NotifyRunComplete was invoked and with what
+// success flag, so tests can assert the manual-vs-scheduled email gate.
+type fakeNotifier struct {
+	calls  int
+	lastOK bool
+}
+
+func (f *fakeNotifier) NotifyRunComplete(_ context.Context, _, _ uuid.UUID, success bool) error {
+	f.calls++
+	f.lastOK = success
+	return nil
+}
+
 var _ = Describe("Run orchestration", func() {
 	It("writes a fresh snapshot, renames it, and updates the portfolio row", func() {
 		snapsDir := GinkgoT().TempDir()
@@ -111,7 +124,7 @@ var _ = Describe("Run orchestration", func() {
 			})
 
 		runID := uuid.New()
-		err := r.Run(context.Background(), ps.row.ID, runID)
+		err := r.Run(context.Background(), ps.row.ID, runID, true)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(ps.markRunning).To(BeTrue())
@@ -124,6 +137,41 @@ var _ = Describe("Run orchestration", func() {
 		Expect(stErr).NotTo(HaveOccurred())
 		_, stErr = os.Stat(ps.snapshotOut + ".tmp")
 		Expect(os.IsNotExist(stErr)).To(BeTrue())
+	})
+
+	It("sends an alert for a scheduled run but not for a manual run", func() {
+		snapsDir := GinkgoT().TempDir()
+
+		fixture := filepath.Join(GinkgoT().TempDir(), "fx.sqlite")
+		Expect(snapshot.BuildTestSnapshot(fixture)).To(Succeed())
+		Expect(os.Setenv("FAKESTRAT_FIXTURE", fixture)).To(Succeed())
+		DeferCleanup(func() { os.Unsetenv("FAKESTRAT_FIXTURE") })
+
+		cfg := backtest.Config{SnapshotsDir: snapsDir, RunnerMode: "host"}
+		resolve := func(_ context.Context, _, _ string) (string, func(), error) {
+			return fakeStratBin, func() {}, nil
+		}
+		newPortfolio := func() *fakePortfolioStore {
+			return &fakePortfolioStore{row: backtest.PortfolioRow{
+				ID: uuid.New(), StrategyCode: "fake", StrategyVer: "v0.0.0",
+				Parameters: map[string]any{}, Benchmark: "SPY", Status: "queued",
+			}}
+		}
+
+		scheduledPS := newPortfolio()
+		scheduledNotifier := &fakeNotifier{}
+		scheduledRunner := backtest.NewRunner(cfg, &backtest.HostRunner{}, backtest.ArtifactBinary,
+			scheduledPS, &fakeRunStoreFull{}, resolve).WithNotifier(scheduledNotifier)
+		Expect(scheduledRunner.Run(context.Background(), scheduledPS.row.ID, uuid.New(), true)).To(Succeed())
+		Expect(scheduledNotifier.calls).To(Equal(1))
+		Expect(scheduledNotifier.lastOK).To(BeTrue())
+
+		manualPS := newPortfolio()
+		manualNotifier := &fakeNotifier{}
+		manualRunner := backtest.NewRunner(cfg, &backtest.HostRunner{}, backtest.ArtifactBinary,
+			manualPS, &fakeRunStoreFull{}, resolve).WithNotifier(manualNotifier)
+		Expect(manualRunner.Run(context.Background(), manualPS.row.ID, uuid.New(), false)).To(Succeed())
+		Expect(manualNotifier.calls).To(Equal(0))
 	})
 
 	It("records a failure when the runner fails", func() {
@@ -143,7 +191,7 @@ var _ = Describe("Run orchestration", func() {
 				return fakeStratBin, func() {}, nil
 			})
 
-		err := r.Run(context.Background(), ps.row.ID, uuid.New())
+		err := r.Run(context.Background(), ps.row.ID, uuid.New(), true)
 		Expect(err).To(HaveOccurred())
 		Expect(errors.Is(err, backtest.ErrRunnerFailed)).To(BeTrue())
 		Expect(ps.markFailed).NotTo(BeEmpty())
@@ -170,7 +218,7 @@ var _ = Describe("Run orchestration", func() {
 				return fakeStratBin, func() { cleanupCalls.Add(1) }, nil
 			})
 
-		Expect(r.Run(context.Background(), ps.row.ID, uuid.New())).To(Succeed())
+		Expect(r.Run(context.Background(), ps.row.ID, uuid.New(), true)).To(Succeed())
 		Expect(cleanupCalls.Load()).To(Equal(int32(1)))
 	})
 
@@ -196,7 +244,7 @@ var _ = Describe("Run orchestration", func() {
 				return fakeStratBin, func() {}, nil
 			}).WithProgressHub(hub)
 
-		Expect(r.Run(context.Background(), ps.row.ID, runID)).To(Succeed())
+		Expect(r.Run(context.Background(), ps.row.ID, runID, true)).To(Succeed())
 
 		var terminal *backtest.TerminalEvent
 		for evt := range events {
@@ -228,7 +276,7 @@ var _ = Describe("Run orchestration", func() {
 				return fakeStratBin, func() {}, nil
 			}).WithProgressHub(hub)
 
-		Expect(r.Run(context.Background(), ps.row.ID, runID)).To(MatchError(backtest.ErrRunnerFailed))
+		Expect(r.Run(context.Background(), ps.row.ID, runID, true)).To(MatchError(backtest.ErrRunnerFailed))
 
 		var terminal *backtest.TerminalEvent
 		for evt := range events {
@@ -259,7 +307,7 @@ var _ = Describe("Run orchestration", func() {
 				return fakeStratBin, func() { cleanupCalls.Add(1) }, nil
 			})
 
-		err := r.Run(context.Background(), ps.row.ID, uuid.New())
+		err := r.Run(context.Background(), ps.row.ID, uuid.New(), true)
 		Expect(errors.Is(err, backtest.ErrRunnerFailed)).To(BeTrue())
 		Expect(cleanupCalls.Load()).To(Equal(int32(1)))
 	})
@@ -283,7 +331,7 @@ var _ = Describe("Run orchestration", func() {
 				return fakeStratBin, func() {}, nil
 			})
 
-		Expect(r.Run(context.Background(), ps.row.ID, uuid.New())).To(Succeed())
+		Expect(r.Run(context.Background(), ps.row.ID, uuid.New(), true)).To(Succeed())
 		Expect(ps.PruneRunsCalls).To(HaveLen(1))
 		Expect(ps.PruneRunsCalls[0]).To(Equal(ps.row.ID))
 	})
@@ -304,7 +352,7 @@ var _ = Describe("Run orchestration", func() {
 				return fakeStratBin, func() {}, nil
 			})
 
-		err := r.Run(context.Background(), ps.row.ID, uuid.New())
+		err := r.Run(context.Background(), ps.row.ID, uuid.New(), true)
 		Expect(errors.Is(err, backtest.ErrRunnerFailed)).To(BeTrue())
 		Expect(ps.PruneRunsCalls).To(HaveLen(1))
 	})
@@ -333,7 +381,7 @@ var _ = Describe("Run orchestration", func() {
 			})
 
 		firstRunID := uuid.New()
-		Expect(r.Run(context.Background(), ps.row.ID, firstRunID)).To(Succeed())
+		Expect(r.Run(context.Background(), ps.row.ID, firstRunID, true)).To(Succeed())
 		firstPath := ps.snapshotOut
 		_, stErr := os.Stat(firstPath)
 		Expect(stErr).NotTo(HaveOccurred())
@@ -344,7 +392,7 @@ var _ = Describe("Run orchestration", func() {
 		ps.row.Status = "queued"
 
 		secondRunID := uuid.New()
-		Expect(r.Run(context.Background(), ps.row.ID, secondRunID)).To(Succeed())
+		Expect(r.Run(context.Background(), ps.row.ID, secondRunID, true)).To(Succeed())
 
 		Expect(ps.snapshotOut).NotTo(Equal(firstPath))
 		_, stErr = os.Stat(ps.snapshotOut)
@@ -382,7 +430,7 @@ var _ = Describe("Run orchestration", func() {
 				return fakeStratBin, func() {}, nil
 			})
 
-		Expect(r.Run(context.Background(), ps.row.ID, uuid.New())).To(Succeed())
+		Expect(r.Run(context.Background(), ps.row.ID, uuid.New(), true)).To(Succeed())
 		_, statErr := os.Stat(stalePath)
 		Expect(os.IsNotExist(statErr)).To(BeTrue())
 	})

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -61,8 +61,8 @@ type backtestRunStoreAdapter struct {
 	store *portfolio.PoolRunStore
 }
 
-func (a backtestRunStoreAdapter) CreateRun(ctx context.Context, portfolioID uuid.UUID, status string) (backtest.RunRow, error) {
-	r, err := a.store.CreateRun(ctx, portfolioID, status)
+func (a backtestRunStoreAdapter) CreateRun(ctx context.Context, portfolioID uuid.UUID, status, trigger string) (backtest.RunRow, error) {
+	r, err := a.store.CreateRun(ctx, portfolioID, status, trigger)
 	if err != nil {
 		return backtest.RunRow{}, err
 	}
@@ -136,7 +136,7 @@ type dispatcherAdapter struct {
 }
 
 func (a dispatcherAdapter) Submit(ctx context.Context, portfolioID uuid.UUID) (uuid.UUID, error) {
-	id, err := a.bt.Submit(ctx, portfolioID)
+	id, err := a.bt.Submit(ctx, portfolioID, backtest.TriggerManual)
 	if errors.Is(err, backtest.ErrQueueFull) {
 		return uuid.Nil, portfolio.ErrQueueFull
 	}
@@ -160,7 +160,7 @@ type schedulerDispatcherAdapter struct {
 }
 
 func (a schedulerDispatcherAdapter) Submit(ctx context.Context, id uuid.UUID) (uuid.UUID, error) {
-	return a.bt.Submit(ctx, id)
+	return a.bt.Submit(ctx, id, backtest.TriggerScheduled)
 }
 
 func init() {

--- a/portfolio/claimdue_test.go
+++ b/portfolio/claimdue_test.go
@@ -1,0 +1,107 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portfolio_test
+
+import (
+	"context"
+	"os"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pv-api/portfolio"
+)
+
+var _ = Describe("ClaimDue scheduled-vs-manual gating", Ordered, func() {
+	var (
+		ctx      = context.Background()
+		pool     *pgxpool.Pool
+		store    *portfolio.PoolStore
+		runStore *portfolio.PoolRunStore
+		ownerSub = "smoke|claimdue-user"
+	)
+
+	BeforeAll(func() {
+		dbURL := os.Getenv("PVAPI_SMOKE_DB_URL")
+		if dbURL == "" {
+			Skip("PVAPI_SMOKE_DB_URL not set; skipping ClaimDue smoke test")
+		}
+		var err error
+		pool, err = pgxpool.New(ctx, dbURL)
+		Expect(err).NotTo(HaveOccurred())
+		store = portfolio.NewPoolStore(pool)
+		runStore = portfolio.NewPoolRunStore(pool)
+
+		_, err = pool.Exec(ctx, `
+			INSERT INTO strategies (short_code, repo_owner, repo_name, clone_url, is_official)
+			VALUES ('__claimdue_stub__', 'smoke', 'smoke', '', true)
+			ON CONFLICT (short_code) DO NOTHING
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		DeferCleanup(func() {
+			// ON DELETE CASCADE removes the portfolios' backtest_runs too.
+			_, _ = pool.Exec(ctx, `DELETE FROM portfolios WHERE owner_sub=$1`, ownerSub)
+			_, _ = pool.Exec(ctx, `DELETE FROM strategies WHERE short_code='__claimdue_stub__'`)
+			pool.Close()
+		})
+	})
+
+	// seedReady inserts a ready, open-ended portfolio and returns its id.
+	seedReady := func(slug string) uuid.UUID {
+		Expect(store.Insert(ctx, portfolio.Portfolio{
+			OwnerSub:             ownerSub,
+			Slug:                 slug,
+			Name:                 slug,
+			StrategyCode:         "__claimdue_stub__",
+			StrategyDescribeJSON: []byte("{}"),
+			Parameters:           map[string]any{},
+			Benchmark:            "SPY",
+			Status:               portfolio.StatusReady,
+			RunRetention:         2,
+		})).To(Succeed())
+		got, err := store.Get(ctx, ownerSub, slug)
+		Expect(err).NotTo(HaveOccurred())
+		return got.ID
+	}
+
+	// completedRunToday creates a run with the given trigger and advances it to
+	// a terminal state. started_at is stamped today, and the success status
+	// means the run no longer trips the queued/running guard -- isolating the
+	// "scheduled run already happened today" gate under test.
+	completedRunToday := func(portfolioID uuid.UUID, trigger string) {
+		run, err := runStore.CreateRun(ctx, portfolioID, "queued", trigger)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(runStore.UpdateRunRunning(ctx, run.ID)).To(Succeed())
+		Expect(runStore.UpdateRunSuccess(ctx, run.ID, "/tmp/claimdue.sqlite", 100)).To(Succeed())
+	}
+
+	It("skips a portfolio whose scheduled run already ran today but claims one with only a manual run", func() {
+		scheduledID := seedReady("claimdue-scheduled")
+		completedRunToday(scheduledID, "scheduled")
+
+		manualID := seedReady("claimdue-manual")
+		completedRunToday(manualID, "manual")
+
+		ids, err := portfolio.ClaimDue(ctx, pool, 10000)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(ids).NotTo(ContainElement(scheduledID), "a scheduled run today should satisfy the daily run")
+		Expect(ids).To(ContainElement(manualID), "a manual run today must not suppress the scheduled daily run")
+	})
+})

--- a/portfolio/db.go
+++ b/portfolio/db.go
@@ -515,22 +515,27 @@ func ApplyUpgrade(ctx context.Context, pool *pgxpool.Pool, portfolioID uuid.UUID
 }
 
 // ClaimDue returns up to batchSize open-ended (end_date IS NULL) portfolio IDs
-// that have not yet run for the current ET calendar day and have no in-flight
-// run. The scheduler owns *when* this is called (8 PM ET on trading days, via
-// tradecron), so there is no wall-clock gate here; the ET-date check only
-// deduplicates a portfolio that already ran today, and the NOT EXISTS guard
-// skips portfolios with a queued or running backtest so repeated claims within
-// one dispatch pass do not double-submit.
+// that have not yet had a *scheduled* run for the current ET calendar day and
+// have no in-flight run. The scheduler owns *when* this is called (8 PM ET on
+// trading days, via tradecron), so there is no wall-clock gate here.
+//
+// The "already ran today" guard counts only scheduled runs: a manual "Run now"
+// must not satisfy the daily run, or it would suppress both the scheduled run
+// and its alert email. The NOT EXISTS on queued/running runs skips portfolios
+// with an in-flight backtest so repeated claims within one dispatch pass do not
+// double-submit.
 func ClaimDue(ctx context.Context, pool *pgxpool.Pool, batchSize int) ([]uuid.UUID, error) {
 	rows, err := pool.Query(ctx, `
 		SELECT id
 		  FROM portfolios p
 		 WHERE p.end_date IS NULL
 		   AND p.status IN ('ready', 'failed')
-		   AND (
-		         p.last_run_at IS NULL
-		         OR (p.last_run_at AT TIME ZONE 'America/New_York')::date
-		            < (now() AT TIME ZONE 'America/New_York')::date
+		   AND NOT EXISTS (
+		         SELECT 1 FROM backtest_runs r
+		          WHERE r.portfolio_id = p.id
+		            AND r.triggered_by = 'scheduled'
+		            AND (r.started_at AT TIME ZONE 'America/New_York')::date
+		                = (now() AT TIME ZONE 'America/New_York')::date
 		       )
 		   AND NOT EXISTS (
 		         SELECT 1 FROM backtest_runs r

--- a/portfolio/handler_test.go
+++ b/portfolio/handler_test.go
@@ -134,7 +134,7 @@ func (f *fakeStore) Delete(_ context.Context, ownerSub, slug string) error {
 
 // RunStore stub methods — not exercised by handler tests.
 
-func (f *fakeStore) CreateRun(_ context.Context, _ uuid.UUID, _ string) (portfolio.Run, error) {
+func (f *fakeStore) CreateRun(_ context.Context, _ uuid.UUID, _, _ string) (portfolio.Run, error) {
 	return portfolio.Run{}, nil
 }
 

--- a/portfolio/prune_test.go
+++ b/portfolio/prune_test.go
@@ -38,14 +38,15 @@ func seedPrunePortfolio(ctx context.Context, pool *pgxpool.Pool) (portfolio.Stor
 	slug := "prune-" + uuid.NewString()[:8]
 
 	p := portfolio.Portfolio{
-		OwnerSub:     ownerSub,
-		Slug:         slug,
-		Name:         "Prune test portfolio",
-		StrategyCode: "__smoke_stub__",
-		Parameters:   map[string]any{},
-		Benchmark:    "SPY",
-		Status:       portfolio.StatusPending,
-		RunRetention: 2, // default retention
+		OwnerSub:             ownerSub,
+		Slug:                 slug,
+		Name:                 "Prune test portfolio",
+		StrategyCode:         "__smoke_stub__",
+		StrategyDescribeJSON: []byte("{}"),
+		Parameters:           map[string]any{},
+		Benchmark:            "SPY",
+		Status:               portfolio.StatusPending,
+		RunRetention:         2, // default retention
 	}
 	Expect(store.Insert(ctx, p)).To(Succeed())
 
@@ -92,7 +93,7 @@ var _ = Describe("PruneRuns", Ordered, func() {
 		store, runStore, portID, _, _ := seedPrunePortfolio(ctx, pool)
 
 		// retention is 2; create only 1 run (no snapshot path)
-		run, err := runStore.CreateRun(ctx, portID, "queued")
+		run, err := runStore.CreateRun(ctx, portID, "queued", "scheduled")
 		Expect(err).NotTo(HaveOccurred())
 		_ = run
 
@@ -107,7 +108,7 @@ var _ = Describe("PruneRuns", Ordered, func() {
 		// Create 4 runs with snapshot paths; retention is 2 so 2 oldest should be pruned.
 		var snapshots []string
 		for i := 0; i < 4; i++ {
-			run, err := runStore.CreateRun(ctx, portID, "queued")
+			run, err := runStore.CreateRun(ctx, portID, "queued", "scheduled")
 			Expect(err).NotTo(HaveOccurred())
 			path := fmt.Sprintf("/tmp/snap-%d-%s.sqlite", i, uuid.NewString()[:8])
 			Expect(runStore.UpdateRunSuccess(ctx, run.ID, path, 100)).To(Succeed())
@@ -130,7 +131,7 @@ var _ = Describe("PruneRuns", Ordered, func() {
 		Expect(store.UpdateRunRetention(ctx, ownerSub, slug, 1)).To(Succeed())
 
 		for i := 0; i < 3; i++ {
-			run, err := runStore.CreateRun(ctx, portID, "queued")
+			run, err := runStore.CreateRun(ctx, portID, "queued", "scheduled")
 			Expect(err).NotTo(HaveOccurred())
 			path := fmt.Sprintf("/tmp/x-%d-%s.sqlite", i, uuid.NewString()[:8])
 			Expect(runStore.UpdateRunSuccess(ctx, run.ID, path, 100)).To(Succeed())

--- a/portfolio/runs.go
+++ b/portfolio/runs.go
@@ -50,7 +50,7 @@ type Run struct {
 // the portfolio layer (we only expose runs the user owns via their
 // portfolio).
 type RunStore interface {
-	CreateRun(ctx context.Context, portfolioID uuid.UUID, status string) (Run, error)
+	CreateRun(ctx context.Context, portfolioID uuid.UUID, status, trigger string) (Run, error)
 	UpdateRunRunning(ctx context.Context, runID uuid.UUID) error
 	UpdateRunSuccess(ctx context.Context, runID uuid.UUID, snapshotPath string, durationMs int32) error
 	UpdateRunFailed(ctx context.Context, runID uuid.UUID, errMsg string, durationMs int32) error
@@ -65,13 +65,13 @@ type PoolRunStore struct {
 
 func NewPoolRunStore(pool *pgxpool.Pool) *PoolRunStore { return &PoolRunStore{pool: pool} }
 
-func (s *PoolRunStore) CreateRun(ctx context.Context, portfolioID uuid.UUID, status string) (Run, error) {
+func (s *PoolRunStore) CreateRun(ctx context.Context, portfolioID uuid.UUID, status, trigger string) (Run, error) {
 	const q = `
-		INSERT INTO backtest_runs (id, portfolio_id, status)
-		VALUES (uuidv7(), $1, $2)
+		INSERT INTO backtest_runs (id, portfolio_id, status, triggered_by)
+		VALUES (uuidv7(), $1, $2, $3)
 		RETURNING id, portfolio_id, status, started_at, finished_at, duration_ms, error, snapshot_path
 	`
-	r, err := scanRun(s.pool.QueryRow(ctx, q, portfolioID, status))
+	r, err := scanRun(s.pool.QueryRow(ctx, q, portfolioID, status, trigger))
 	if err != nil && uniqueViolation(err) {
 		return Run{}, ErrRunInFlight
 	}

--- a/portfolio/runs_test.go
+++ b/portfolio/runs_test.go
@@ -55,8 +55,8 @@ var _ = Describe("PoolRunStore", Ordered, func() {
 
 		portfolioID = uuid.New()
 		_, err = pool.Exec(context.Background(), `
-			INSERT INTO portfolios (id, owner_sub, slug, name, strategy_code, strategy_ver, parameters, benchmark, mode, status)
-			VALUES ($1, 'smoke|user', 'run-store-smoke-slug', 'smoke', '__smoke_stub__', 'v0.0.0', '{}'::jsonb, 'SPY', 'one_shot', 'pending')
+			INSERT INTO portfolios (id, owner_sub, slug, name, strategy_code, strategy_ver, strategy_clone_url, strategy_describe_json, parameters, benchmark, status)
+			VALUES ($1, 'smoke|user', 'run-store-smoke-slug', 'smoke', '__smoke_stub__', 'v0.0.0', '', '{}'::jsonb, '{}'::jsonb, 'SPY', 'pending')
 		`, portfolioID)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -68,7 +68,7 @@ var _ = Describe("PoolRunStore", Ordered, func() {
 	})
 
 	It("creates a queued run and advances it to success", func() {
-		r, err := store.CreateRun(context.Background(), portfolioID, "queued")
+		r, err := store.CreateRun(context.Background(), portfolioID, "queued", "scheduled")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(r.Status).To(Equal("queued"))
 
@@ -91,13 +91,13 @@ var _ = Describe("PoolRunStore", Ordered, func() {
 		// Create one queued run, then try to create another. The partial unique
 		// index should reject the second insert and PoolRunStore translates the
 		// 23505 violation to portfolio.ErrRunInFlight.
-		first, err := store.CreateRun(context.Background(), portfolioID, "queued")
+		first, err := store.CreateRun(context.Background(), portfolioID, "queued", "scheduled")
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
 			_, _ = pool.Exec(context.Background(), `DELETE FROM backtest_runs WHERE id=$1`, first.ID)
 		})
 
-		_, err = store.CreateRun(context.Background(), portfolioID, "queued")
+		_, err = store.CreateRun(context.Background(), portfolioID, "queued", "scheduled")
 		Expect(err).To(MatchError(portfolio.ErrRunInFlight))
 	})
 })
@@ -135,14 +135,15 @@ var _ = Describe("PoolStore run_retention", Ordered, func() {
 
 	It("persists an explicit run_retention", func() {
 		p := portfolio.Portfolio{
-			OwnerSub:     "smoke|rr-user",
-			Slug:         "rr-explicit-test",
-			Name:         "RR explicit",
-			StrategyCode: "__rr_stub__",
-			Parameters:   map[string]any{},
-			Benchmark:    "SPY",
-			Status:       portfolio.StatusPending,
-			RunRetention: 5,
+			OwnerSub:             "smoke|rr-user",
+			Slug:                 "rr-explicit-test",
+			Name:                 "RR explicit",
+			StrategyCode:         "__rr_stub__",
+			StrategyDescribeJSON: []byte("{}"),
+			Parameters:           map[string]any{},
+			Benchmark:            "SPY",
+			Status:               portfolio.StatusPending,
+			RunRetention:         5,
 		}
 		Expect(store.Insert(ctx, p)).To(Succeed())
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -35,6 +35,19 @@ import (
 // from the calendar loaded at startup, so the run never happens on a closed day.
 const scheduleSpec = "0 20 * * *"
 
+// nyseLoc anchors the schedule to Eastern time. tradecron interprets a plain
+// numeric cron's clock field in the location of the time.Time handed to Next(),
+// not in its internal Eastern calendar -- so "0 20" fires at 8 PM in whatever
+// zone we pass. On a UTC host that is 8 PM UTC (4 PM ET); localizing now() to
+// Eastern is what makes the spec mean 8 PM ET regardless of server timezone.
+var nyseLoc = func() *time.Location {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		return time.UTC
+	}
+	return loc
+}()
+
 // PortfolioStore is the subset of portfolio store operations the scheduler needs.
 type PortfolioStore interface {
 	ClaimDue(ctx context.Context, batchSize int) ([]uuid.UUID, error)
@@ -74,13 +87,13 @@ func (s *Scheduler) Run(ctx context.Context) error {
 
 	// Catch up a fire we may have slept through -- e.g. a restart after 8 PM ET
 	// on a trading day. dispatchDue skips portfolios that already ran today.
-	now := time.Now()
+	now := time.Now().In(nyseLoc)
 	if last, ok := mostRecentFire(sched, now); ok && sameDay(last, now) {
 		s.dispatchDue(ctx, sched.Next(now))
 	}
 
 	for {
-		fire := sched.Next(time.Now())
+		fire := sched.Next(time.Now().In(nyseLoc))
 		timer := time.NewTimer(time.Until(fire))
 		select {
 		case <-ctx.Done():

--- a/sql/migrations/16_backtest_run_trigger.down.sql
+++ b/sql/migrations/16_backtest_run_trigger.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE backtest_runs DROP COLUMN IF EXISTS triggered_by;

--- a/sql/migrations/16_backtest_run_trigger.up.sql
+++ b/sql/migrations/16_backtest_run_trigger.up.sql
@@ -1,0 +1,15 @@
+-- Record whether a backtest run was started by the nightly scheduler or by a
+-- manual user action. ClaimDue gates the daily run on scheduled runs only, so a
+-- manual "Run now" no longer counts as the day's scheduled run -- which would
+-- otherwise suppress both the scheduled run and its alert email. Manual runs
+-- also skip the alert path entirely.
+--
+-- Existing rows are backfilled to 'scheduled' to preserve the prior
+-- "already ran today" semantics across the migration; the column default then
+-- flips to 'manual' so any future insert that omits the value errs toward the
+-- non-suppressing, non-emailing case.
+ALTER TABLE backtest_runs
+    ADD COLUMN triggered_by TEXT NOT NULL DEFAULT 'scheduled'
+        CHECK (triggered_by IN ('scheduled', 'manual'));
+
+ALTER TABLE backtest_runs ALTER COLUMN triggered_by SET DEFAULT 'manual';


### PR DESCRIPTION
## Problem

Scheduled portfolio update emails were "not always sending." Investigation traced it to two compounding bugs, confirmed against the production data:

1. **Timezone-naive schedule.** The scheduler passed `time.Now()` (server-local) into tradecron, which interprets a numeric cron's clock field in the caller's zone. On a UTC host `"0 20"` fired at **8 PM UTC = 4 PM ET**, not the intended 8 PM ET. (tradecron uses ET for its trading-day calendar but not for the numeric clock field.)
2. **Manual runs cannibalized the scheduled daily.** A manual "Run now" went through the same `ClaimDue` "ran today" guard and per-ET-day alert dedup as scheduled runs. So a manual run earlier in the ET day both made `ClaimDue` skip that evening's scheduled run *and* consumed the daily alert slot — silently dropping the scheduled email (the reported `adm-custom-yott` case).

## Fix

- **Pin the schedule to Eastern** — `scheduler` localizes `now` to `America/New_York`, so `"0 20"` means 8 PM ET on any host.
- **Distinguish manual vs scheduled runs** via a new `backtest_runs.triggered_by` column (migration 16), threaded through `Submit → CreateRun → orchestrator` at the existing `cmd/server.go` adapters (handler/scheduler interfaces unchanged):
  - Manual runs **send no alert email** (success or failure).
  - `ClaimDue` counts **only scheduled runs** as the day's run, so a manual run can't suppress the scheduled daily.

## Tests / validation

- New orchestrator unit test: scheduled run notifies, manual run does not.
- New `ClaimDue` smoke test: a scheduled-today portfolio is excluded; a manual-only one is still claimed.
- Fixed pre-existing stale smoke-test seeds (dropped `mode` column, now-required `strategy_describe_json`) that had been silently skipping in CI.
- `golangci-lint`: 0 issues. Full suite green, including DB-backed smoke tests. Migration 16 applied cleanly to a local Postgres.

## Deploy note

Migration 16 applies automatically on startup (golang-migrate). It's additive (`ADD COLUMN ... DEFAULT ... CHECK`), backfilling existing rows to `'scheduled'` then defaulting future inserts to `'manual'`.