### PR TITLE
fix(strategy): raise ephemeral build timeout default to 5m

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -179,7 +179,7 @@ func init() {
 	serverCmd.Flags().String("strategy-official-dir", "", "where installed official strategy binaries live (default: <data-dir>/strategies/official)")
 	serverCmd.Flags().String("strategy-github-query", "owner:penny-vault topic:pvbt-strategy", "GitHub search query for official strategies (owner filter applied client-side)")
 	serverCmd.Flags().String("strategy-ephemeral-dir", "", "ephemeral build dir for unofficial strategies (default: <data-dir>/strategies/ephemeral)")
-	serverCmd.Flags().Duration("strategy-ephemeral-install-timeout", 60*time.Second, "max time for one ephemeral clone+build")
+	serverCmd.Flags().Duration("strategy-ephemeral-install-timeout", 5*time.Minute, "max time for one ephemeral clone+build")
 	serverCmd.Flags().String("backtest-snapshots-dir", "", "directory where backtest snapshot files are stored (default: <data-dir>/snapshots)")
 	serverCmd.Flags().Duration("backtest-orphan-gc-interval", 7*24*time.Hour, "how often to sweep snapshot files no DB row references; <0 disables (sweep still runs at startup)")
 	serverCmd.Flags().String("runner-docker-socket", "unix:///var/run/docker.sock", "Docker daemon socket URL")

--- a/cmd/viper.go
+++ b/cmd/viper.go
@@ -45,7 +45,7 @@ func setViperDefaults() {
 	viper.SetDefault("scheduler.tick_interval", "60s")
 	viper.SetDefault("scheduler.batch_size", 32)
 	viper.SetDefault("scheduler.enabled", true)
-	viper.SetDefault("strategy.ephemeral_install_timeout", 60*time.Second)
+	viper.SetDefault("strategy.ephemeral_install_timeout", 5*time.Minute)
 	viper.SetDefault("strategy.stats_refresh_time", "17:00")
 	viper.SetDefault("strategy.stats_start_date", "2010-01-01")
 	viper.SetDefault("strategy.stats_tick_interval", 5*time.Minute)

--- a/strategy/ephemeral.go
+++ b/strategy/ephemeral.go
@@ -29,7 +29,7 @@ import (
 	"time"
 )
 
-const defaultEphemeralTimeout = 60 * time.Second
+const defaultEphemeralTimeout = 5 * time.Minute
 
 // EphemeralOptions configures a single EphemeralBuild call.
 type EphemeralOptions struct {


### PR DESCRIPTION
## Problem

Backtests against unofficial (clone-URL) strategies were failing with:

```
backtest: strategy binary not installed: ephemeral: go build: signal: killed
go: downloading github.com/penny-vault/pvbt v0.9.3
go: downloading ...
```

`strategy.EphemeralBuild` runs `git clone` + `go build` under a single deadline. On a cold module cache, downloading pvbt's full dependency tree (charm/bubbletea, modernc-sqlite, gonum, etc.) plus compiling did not fit in 60s, so `go build` was SIGKILLed mid-download.

## Fix

Bump the ephemeral build timeout default from 60s to 5m in all three default sites:

- `cmd/server.go` — `--strategy-ephemeral-install-timeout` flag default
- `cmd/viper.go` — `strategy.ephemeral_install_timeout` config default
- `strategy/ephemeral.go` — `defaultEphemeralTimeout` fallback (also covers the Docker path)

The module cache (`GOMODCACHE`) is shared and persists across builds, so the download tax is paid once — the first build just needs room to warm it; later builds stay well under the limit.

## Testing

- `go build ./...` clean
- `golangci-lint run` on changed packages: 0 issues
- `go test ./cmd/... ./strategy/...` pass