### PR TITLE
fix(snapshot): include cash sleeve in holdings history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GET /portfolios/{slug}/trailing-returns` for benchmark windowed returns.
 
 ### Fixed
+- Holdings history (`GET /portfolios/{slug}/holdings/history`) now includes
+  the cash sleeve (`$CASH`) in each batch's holdings. Previously cash was
+  omitted because it never flows through a transaction, so weeks split
+  between an asset and cash appeared to hold only the asset, and an all-cash
+  week returned no holdings at all.
 - Alert emails no longer arrive on weekends or NYSE holidays. The portfolio
   update that triggers them no longer runs on a closed-market day, so no
   update with a spurious one-day return computed off stale data is sent.

--- a/snapshot/holdings.go
+++ b/snapshot/holdings.go
@@ -279,6 +279,41 @@ func (r *Reader) holdingsHistoryBatch(ctx context.Context, batchID int64, ts tim
 		return entry, fmt.Errorf("holdings history batch %d: %w", batchID, err)
 	}
 
+	entry.Items = ledgerToHistoricalHoldings(ledger, dailyMV)
+
+	pv, err := r.readPortfolioValueOn(ctx, ts)
+	if err != nil {
+		return entry, fmt.Errorf("holdings history batch %d: %w", batchID, err)
+	}
+	if pv == nil && len(dailyMV) > 0 {
+		var sum float64
+		for _, mv := range dailyMV {
+			sum += mv
+		}
+		pv = &sum
+	}
+	entry.PortfolioValue = pv
+
+	ann, err := r.readBatchAnnotations(ctx, batchID)
+	if err != nil {
+		return entry, err
+	}
+	if len(ann) > 0 {
+		entry.Annotations = &ann
+	}
+	return entry, nil
+}
+
+// ledgerToHistoricalHoldings converts a replayed ledger into sorted
+// HistoricalHoldings, preferring positions_daily market values (current
+// prices) over the stale ledger lastPrice. The cash sleeve is then appended
+// from positions_daily: cash never flows through transactions, so without
+// this the Tickers column omits cash (showing only the equity/hedge leg) and
+// a 100%-cash batch yields an empty item list. Cash quantity equals its
+// market value (unit price $1).
+func ledgerToHistoricalHoldings(ledger map[string]*ledgerRow, dailyMV map[string]float64) []openapi.HistoricalHolding {
+	items := []openapi.HistoricalHolding{}
+
 	tickers := make([]string, 0, len(ledger))
 	for t := range ledger {
 		tickers = append(tickers, t)
@@ -303,30 +338,19 @@ func (r *Reader) holdingsHistoryBatch(ctx context.Context, batchID int64, ts tim
 			figi := pos.figi
 			h.Figi = &figi
 		}
-		entry.Items = append(entry.Items, h)
+		items = append(items, h)
 	}
 
-	pv, err := r.readPortfolioValueOn(ctx, ts)
-	if err != nil {
-		return entry, fmt.Errorf("holdings history batch %d: %w", batchID, err)
+	if cash, ok := dailyMV[cashTicker]; ok && cash != 0 {
+		items = append(items, openapi.HistoricalHolding{
+			Ticker:         cashTicker,
+			Quantity:       cash,
+			AvgCost:        1,
+			LastTradeValue: cash,
+		})
 	}
-	if pv == nil && len(dailyMV) > 0 {
-		var sum float64
-		for _, mv := range dailyMV {
-			sum += mv
-		}
-		pv = &sum
-	}
-	entry.PortfolioValue = pv
 
-	ann, err := r.readBatchAnnotations(ctx, batchID)
-	if err != nil {
-		return entry, err
-	}
-	if len(ann) > 0 {
-		entry.Annotations = &ann
-	}
-	return entry, nil
+	return items
 }
 
 // readPortfolioValueOn returns the perf_data portfolio equity on the given

--- a/snapshot/holdings_test.go
+++ b/snapshot/holdings_test.go
@@ -70,33 +70,41 @@ var _ = Describe("Holdings", func() {
 			// batch 2 (dividend + annotation) and batch 3 (annotation-only, no-op hold) are now included
 			Expect(resp.Items).To(HaveLen(4))
 
-			// batch 1: initial buy
+			// batch 1: initial buy. The cash sleeve from positions_daily is
+			// appended after the ledger holdings.
 			Expect(resp.Items[0].BatchId).To(Equal(int64(1)))
-			Expect(resp.Items[0].Items).To(HaveLen(1))
+			Expect(resp.Items[0].Items).To(HaveLen(2))
 			Expect(resp.Items[0].Items[0].Ticker).To(Equal("VTI"))
 			Expect(resp.Items[0].Items[0].Quantity).To(BeNumerically("~", 100, 0.01))
 			Expect(resp.Items[0].Items[0].LastTradeValue).To(BeNumerically("~", 100*100, 0.01))
+			Expect(resp.Items[0].Items[1].Ticker).To(Equal("$CASH"))
+			Expect(resp.Items[0].Items[1].LastTradeValue).To(BeNumerically("~", 90000, 0.01))
 			Expect(resp.Items[0].PortfolioValue).NotTo(BeNil())
 			Expect(*resp.Items[0].PortfolioValue).To(BeNumerically("~", 100000, 0.01))
 			Expect(*resp.Items[0].Annotations).To(HaveKeyWithValue("reason", "initial allocation"))
 
 			// batch 2: dividend-only batch — annotation present, ledger unchanged from batch 1
 			Expect(resp.Items[1].BatchId).To(Equal(int64(2)))
-			Expect(resp.Items[1].Items).To(HaveLen(1))
+			Expect(resp.Items[1].Items).To(HaveLen(2))
 			Expect(resp.Items[1].Items[0].Ticker).To(Equal("VTI"))
 			Expect(resp.Items[1].Items[0].Quantity).To(BeNumerically("~", 100, 0.01))
+			Expect(resp.Items[1].Items[1].Ticker).To(Equal("$CASH"))
+			Expect(resp.Items[1].Items[1].LastTradeValue).To(BeNumerically("~", 91800, 0.01))
 			Expect(*resp.Items[1].PortfolioValue).To(BeNumerically("~", 102000, 0.01))
 			Expect(*resp.Items[1].Annotations).To(HaveKeyWithValue("reason", "dividend payment"))
 
 			// batch 3: annotation-only hold batch — the case being fixed
 			Expect(resp.Items[2].BatchId).To(Equal(int64(3)))
-			Expect(resp.Items[2].Items).To(HaveLen(1))
+			Expect(resp.Items[2].Items).To(HaveLen(2))
 			Expect(resp.Items[2].Items[0].Ticker).To(Equal("VTI"))
 			Expect(resp.Items[2].Items[0].Quantity).To(BeNumerically("~", 100, 0.01))
+			Expect(resp.Items[2].Items[1].Ticker).To(Equal("$CASH"))
+			Expect(resp.Items[2].Items[1].LastTradeValue).To(BeNumerically("~", 92700, 0.01))
 			Expect(*resp.Items[2].PortfolioValue).To(BeNumerically("~", 103000, 0.01))
 			Expect(*resp.Items[2].Annotations).To(HaveKeyWithValue("reason", "final state"))
 
-			// batch 4: annual rebalance sold VTI, bought QQQ
+			// batch 4: annual rebalance sold VTI, bought QQQ. No positions_daily
+			// row for 2024-01-11, so no cash sleeve is merged in.
 			Expect(resp.Items[3].BatchId).To(Equal(int64(4)))
 			Expect(resp.Items[3].Items).To(HaveLen(1))
 			Expect(resp.Items[3].Items[0].Ticker).To(Equal("QQQ"))


### PR DESCRIPTION
## Problem

A run that rotated into its hedge basket (half GLD / half cash, then 100% cash) displayed a misleading portfolio value: the value appeared to halve when going into GLD and an all-cash week showed a blank row.

Root cause: holdings-history \`Items\` were built solely from the transaction ledger. Cash never flows through a transaction (it lives only in \`positions_daily\`), so it was always dropped from \`Items\`. Weeks split between an asset and cash showed only the asset, and an all-cash week returned no holdings at all.

The data and the \`portfolioValue\` field were correct throughout; only the per-position \`Items\` list was incomplete.

## Fix

Merge the \`\$CASH\` sleeve from \`positions_daily\` into each batch's \`Items\` (quantity = market value, unit price \$1). Extracted \`ledgerToHistoricalHoldings\` to keep \`holdingsHistoryBatch\` under the gocyclo limit.

Verified against the real run: every batch now carries \`\$CASH\`, and the all-cash week reports the full cash position instead of a blank row.

## Tests

- Updated \`snapshot/holdings_test.go\` for the cash sleeve.
- Full build, test suite, and lint pass.