### PR TITLE
feat(alert): show execution date for trades to execute

### DIFF
--- a/alert/checker.go
+++ b/alert/checker.go
@@ -400,7 +400,18 @@ func (c *Checker) fillHoldingsAndTrades(ctx context.Context, p *email.Payload, p
 		log.Warn().Err(err).Msg("alert: latest batch trades")
 		return
 	}
+	fillTrades(p, trades)
+}
+
+// fillTrades populates the trade rows and the shared execution date on the
+// payload from the most recent rebalance batch.
+func fillTrades(p *email.Payload, trades []snapshot.LatestBatchTrade) {
 	for _, tx := range trades {
+		if p.TradesDate == "" && tx.Date != "" {
+			if d, err := time.Parse("2006-01-02", tx.Date); err == nil {
+				p.TradesDate = d.Format("January 2, 2006")
+			}
+		}
 		action := strings.ToUpper(tx.Type[:1]) + tx.Type[1:]
 		actionColor, actionBgColor := "#16a34a", "#dcfce7"
 		if tx.Type == "sell" {

--- a/alert/email/template.go
+++ b/alert/email/template.go
@@ -105,6 +105,11 @@ type Payload struct {
 	SinceLabel   string
 	DeltaColor   string
 
+	// TradesDate is the formatted date the trades should be executed on
+	// (the rebalance date shared by every row in Trades). Empty when there
+	// are no trades.
+	TradesDate string
+
 	// Returns drives the wide (desktop) returns grid: row 0 is the portfolio,
 	// row 1 (when present) is the benchmark, each spanning Day/WTD/MTD/YTD/1Y.
 	Returns []ReturnsRow
@@ -258,7 +263,11 @@ func buildPlaintext(p Payload) string {
 	if len(p.Trades) == 0 {
 		b.WriteString("No trades required.\n\n")
 	} else {
-		b.WriteString("Trades to Execute:\n")
+		if p.TradesDate != "" {
+			b.WriteString("Trades to Execute (" + p.TradesDate + "):\n")
+		} else {
+			b.WriteString("Trades to Execute:\n")
+		}
 		for _, tr := range p.Trades {
 			fmt.Fprintf(&b, "  %s %s %s shares (~%s)\n", tr.Action, tr.Ticker, tr.Shares, tr.Value)
 		}

--- a/alert/email/templates/src/success.mjml
+++ b/alert/email/templates/src/success.mjml
@@ -149,7 +149,8 @@
       <mj-column>
         <mj-text font-size="11px" font-weight="700" color="#0f172a"
                  text-transform="uppercase" letter-spacing="1px"
-                 padding="0 0 16px" css-class="pv-heading">Trades to Execute</mj-text>
+                 padding="0 0 4px" css-class="pv-heading">Trades to Execute</mj-text>
+        <mj-text font-size="13px" color="#64748b" padding="0 0 16px">{{if .TradesDate}}Execute on {{.TradesDate}}{{end}}</mj-text>
         <mj-text padding="0 0 24px">
           <table class="pv-table" width="100%" cellpadding="0" cellspacing="0"
                  style="border-collapse:collapse;width:100%;border-radius:8px;overflow:hidden;">

--- a/alert/email/templates/success.html
+++ b/alert/email/templates/success.html
@@ -476,7 +476,7 @@
                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align: top" width="100%">
                     <tbody>
                       <tr>
-                        <td align="left" class="pv-heading" style="font-size: 0px; padding: 0 0 16px; word-break: break-word">
+                        <td align="left" class="pv-heading" style="font-size: 0px; padding: 0 0 4px; word-break: break-word">
                           <div
                             style="
                               font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif;
@@ -490,6 +490,14 @@
                             "
                           >
                             Trades to Execute
+                          </div>
+                        </td>
+                      </tr>
+
+                      <tr>
+                        <td align="left" style="font-size: 0px; padding: 0 0 16px; word-break: break-word">
+                          <div style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; line-height: 1; text-align: left; color: #64748b">
+                            {{if .TradesDate}}Execute on {{.TradesDate}}{{end}}
                           </div>
                         </td>
                       </tr>

--- a/snapshot/transactions.go
+++ b/snapshot/transactions.go
@@ -31,6 +31,7 @@ import (
 type LatestBatchTrade struct {
 	Ticker   string
 	Type     string
+	Date     string // execution date, "2006-01-02"
 	Quantity float64
 	Price    float64
 	Amount   float64
@@ -41,7 +42,7 @@ type LatestBatchTrade struct {
 // slice when no such batch exists.
 func (r *Reader) LatestBatchTrades(ctx context.Context) ([]LatestBatchTrade, error) {
 	const q = `
-		SELECT t.ticker, t.type, t.quantity, t.price, t.amount
+		SELECT t.ticker, t.type, t.date, t.quantity, t.price, t.amount
 		  FROM transactions t
 		 WHERE t.batch_id = (
 		           SELECT MAX(batch_id) FROM transactions
@@ -59,7 +60,7 @@ func (r *Reader) LatestBatchTrades(ctx context.Context) ([]LatestBatchTrade, err
 	out := []LatestBatchTrade{}
 	for rows.Next() {
 		var trade LatestBatchTrade
-		if err := rows.Scan(&trade.Ticker, &trade.Type, &trade.Quantity, &trade.Price, &trade.Amount); err != nil {
+		if err := rows.Scan(&trade.Ticker, &trade.Type, &trade.Date, &trade.Quantity, &trade.Price, &trade.Amount); err != nil {
 			return nil, fmt.Errorf("latest batch trades scan: %w", err)
 		}
 		out = append(out, trade)

--- a/snapshot/transactions_test.go
+++ b/snapshot/transactions_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Transactions", func() {
 			sell := trades[0]
 			Expect(sell.Ticker).To(Equal("VTI"))
 			Expect(sell.Type).To(Equal("sell"))
+			Expect(sell.Date).To(Equal("2024-01-11"))
 			Expect(sell.Quantity).To(BeNumerically("==", 100))
 			Expect(sell.Price).To(BeNumerically("==", 110))
 			Expect(sell.Amount).To(BeNumerically("==", 11000))
@@ -57,6 +58,7 @@ var _ = Describe("Transactions", func() {
 			buy := trades[1]
 			Expect(buy.Ticker).To(Equal("QQQ"))
 			Expect(buy.Type).To(Equal("buy"))
+			Expect(buy.Date).To(Equal("2024-01-11"))
 			Expect(buy.Quantity).To(BeNumerically("==", 90))
 			Expect(buy.Price).To(BeNumerically("==", 110))
 			Expect(buy.Amount).To(BeNumerically("==", 9900))


### PR DESCRIPTION
## Summary

The "Trades to Execute" section of the alert email now shows the date the trades should have been executed on. Every trade in a rebalance batch shares one execution date (the `date` column on `transactions`), so it renders once as a subtitle under the heading — "Execute on June 1, 2026" — rather than a redundant per-row column.

## Changes

- `snapshot/transactions.go` — added `Date` to `LatestBatchTrade`; select/scan `t.date` in `LatestBatchTrades`.
- `alert/checker.go` — extracted trade-row building into a `fillTrades` helper that parses the trade date and sets `Payload.TradesDate` (formatted `January 2, 2006` to match `RunDate`).
- `alert/email/template.go` — added `TradesDate` to `Payload`; plaintext now emits `Trades to Execute (June 1, 2026):`.
- `alert/email/templates/src/success.mjml` — added a gray subtitle line; recompiled to `success.html` via `npm run build`.
- `snapshot/transactions_test.go` — added `Date` assertions for the buy/sell rows.

## Verification

- `golangci-lint run` — 0 issues
- `go test ./snapshot/... ./alert/...` — passes